### PR TITLE
extract-non-string-value

### DIFF
--- a/lib/bora/stack.rb
+++ b/lib/bora/stack.rb
@@ -152,6 +152,7 @@ class Bora
     end
 
     def process_param_substitutions(val)
+      return val unless val.is_a? String
       old_val = nil
       while old_val != val
         old_val = val


### PR DESCRIPTION
Sometimes we need to have some values like: 
```yml
db_cluster_parameter_group: 
  id: "ds-management-app-db-cluster-parameter-group"
  description: "parameter group for aurora db cluster"
  family: "aurora5.6"
  parameters:
    character_set_client: "utf8"
    character_set_connection: "utf8"
    character_set_database: "utf8"
    character_set_results: "utf8"
    character_set_server: "utf8"
    collation_connection: "utf8_unicode_ci"
    collation_server: "utf8_unicode_ci"
```
It'll be nice to be able to get the `db_cluster_parameter_group` as a `Hash` object instead of a `String`